### PR TITLE
Add Javadoc configuration for framework module

### DIFF
--- a/com.mursu/pom.xml
+++ b/com.mursu/pom.xml
@@ -40,6 +40,37 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.1.2</version>
             </plugin>
+            <!-- Plugin for creating Javadoc in taget/site/apidocs -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>3.6.3</version>
+                <configuration>
+                    <source>17</source>
+                    <failOnError>false</failOnError>
+                    <subpackages>
+                        <!-- Run-->
+                        <!--     cd com.mursu -->
+                        <!--     mvn javadoc:javadoc -->
+                        <!-- to generate javadoc in taget/site/apidocs-->
+
+                        <!-- Javadoc for eds.framework -->
+                        eds.framework,
+
+                        <!-- Javadoc for eds.model -->
+                        <!-- eds.model,-->
+
+                        <!-- Javadoc for controller -->
+                        <!-- controller,-->
+
+                        <!-- Javadoc for view -->
+                        <!-- view,-->
+
+                        <!-- Javadoc for distributions -->
+                        <!-- eduni.distributions,-->
+                    </subpackages>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/com.mursu/src/main/java/eds/framework/Clock.java
+++ b/com.mursu/src/main/java/eds/framework/Clock.java
@@ -1,20 +1,34 @@
 package eds.framework;
 
-// DONE (by Ks)
-
+/**
+ * Singleton clock.
+ *
+ * The Clock class maintains the current simulation time.
+ * Only one instance of this class exists during execution.
+ * The time value is represented as a double.
+ */
 public class Clock {
-	// luokan ainoa instanssi
+
+	// the only instance of the class
 	private static Clock instance;
 
-	// simulaation nykyinen aika
+	// current simulation time
 	private double time;
 
-	// yksityinen konstruktori, new Clock() ei ole sallittu
+	/**
+	 * Private constructor to prevent external instantiation.
+	 * Initializes simulation time to 0.
+	 */
 	private Clock() {
 		this.time = 0;
 	}
 
-	// hae ainoa instanssi
+	/**
+	 * Returns the single instance of the Clock.
+	 * If the instance does not exist yet, it is created.
+	 *
+	 * @return the singleton Clock instance
+	 */
 	public static Clock getInstance() {
 		if (instance == null) {
 			instance = new Clock();
@@ -22,12 +36,20 @@ public class Clock {
 		return instance;
 	}
 
-	// aseta aika
+	/**
+	 * Sets the current simulation time.
+	 *
+	 * @param time the new simulation time
+	 */
 	public void setTime(double time) {
 		this.time = time;
 	}
 
-	// hae aika
+	/**
+	 * Returns the current simulation time.
+	 *
+	 * @return current simulation time
+	 */
 	public double getTime() {
 		return time;
 	}

--- a/com.mursu/src/main/java/eds/framework/Event.java
+++ b/com.mursu/src/main/java/eds/framework/Event.java
@@ -1,42 +1,74 @@
 package eds.framework;
 
-// DONE (by Ks)
 import eds.model.Order;
 
+/**
+ * Represents a simulation event.
+ *
+ * An Event contains a type of event, the simulation time at which it occurs,
+ * and the related Order. Events are comparable by time and are
+ * stored in a priority queue.
+ */
 public class Event implements Comparable<Event> {
 
-	// Tapahtuman tyyppi (katso enum EventType)
+	// event type (see IEventType)
 	private final IEventType type;
 
-	// Simulaatioaika, jolloin tapahtuma suoritetaan
+	// simulation time when the event is occured
 	private final double time;
 
-	// Tähän tapahtumaan liittyvä tilaus (Order)
+	// order associated with this event
 	private final Order order;
 
-	// Luo uuden tapahtuman annetulla tyypillä, ajalla ja tilauksella
+	/**
+	 * Creates a new Event.
+	 *
+	 * @param type  the type of the event
+	 * @param time  the simulation time when the event occurs
+	 * @param order the order associated with the event
+	 */
 	public Event(IEventType type, double time, Order order) {
 		this.type = type;
 		this.time = time;
 		this.order = order;
 	}
 
-	// Palauttaa tapahtuman tyypin
+	/**
+	 * Returns the event type.
+	 *
+	 * @return the event type
+	 */
 	public IEventType getType() {
 		return type;
 	}
 
-	// Palauttaa tapahtuman ajan
+	/**
+	 * Returns the simulation time of the event.
+	 *
+	 * @return event execution time
+	 */
 	public double getTime() {
 		return time;
 	}
 
-	// Palauttaa tapahtumaan liittyvän tilauksen
+	/**
+	 * Returns the order associated with this event.
+	 *
+	 * @return the related order
+	 */
 	public Order getOrder() {
 		return order;
 	}
 
-	// Vertaa tapahtumia ajan perusteella (käytetään prioriteettijonossa)
+	/**
+	 * Compares this event with another event based on time.
+	 * Used for ordering events in a priority queue.
+	 *
+	 * @param other the event to compare with
+	 * @return a negative integer, zero, or a positive integer
+	 *         as this event time is less than, equal to,
+	 *         or greater than the specified event time
+	 */
 	@Override
 	public int compareTo(Event other) {
 		return Double.compare(this.time, other.time);

--- a/com.mursu/src/main/java/eds/framework/EventList.java
+++ b/com.mursu/src/main/java/eds/framework/EventList.java
@@ -2,23 +2,43 @@ package eds.framework;
 
 import java.util.PriorityQueue;
 
-// DONE (by Ks)
-
+/**
+ * Maintains a list of simulation events ordered by execution time.
+ *
+ * Events are stored in a PriorityQueue and sorted according to
+ * their natural ordering based on Event.compareTo.
+ * The earliest event is always processed first.
+ */
 public class EventList {
-	// Prioriteettijono, joka järjestää tapahtumat ajan mukaan
+
+	// priority queue ordered by event time
 	private final PriorityQueue<Event> events = new PriorityQueue<>();
 
-	// Lisää uusi tapahtuma listaan
+	/**
+	 * Adds a new event to the event list.
+	 *
+	 * @param event the event to be added
+	 */
 	public void add(Event event) {
 		events.add(event);
 	}
 
-	// Poistaa ja palauttaa aikaisimman tapahtuman
+	/**
+	 * Removes and returns the earliest event in the list.
+	 *
+	 * @return the next event to be processed,
+	 *         or null if the list is empty
+	 */
 	public Event remove() {
 		return events.poll();
 	}
 
-	// Palauttaa seuraavan tapahtuman ajan
+	/**
+	 * Returns the execution time of the next event.
+	 *
+	 * @return the time of the next scheduled event
+	 * @throws IllegalStateException if the event list is empty
+	 */
 	public double getNextTime() {
 		if (events.isEmpty()) {
 			throw new IllegalStateException("EventList is empty");
@@ -26,7 +46,11 @@ public class EventList {
 		return events.peek().getTime();
 	}
 
-	// Tarkistaa onko lista tyhjä
+	/**
+	 * Checks whether the event list is empty.
+	 *
+	 * @return true if there are no events, false otherwise
+	 */
 	public boolean isEmpty() {
 		return events.isEmpty();
 	}

--- a/com.mursu/src/main/java/eds/framework/ServicePoint.java
+++ b/com.mursu/src/main/java/eds/framework/ServicePoint.java
@@ -2,69 +2,82 @@ package eds.framework;
 
 import eduni.distributions.Negexp;
 import java.util.LinkedList;
-
-// DONE (by Ks)
 import eds.model.Order;
 
+/**
+ * Represents a service point.
+ *
+ * A ServicePoint maintains a queue of orders and processes them
+ * one at a time. Service times are generated using an exponential
+ * distribution (Negexp) by default. When service is completed, a new event
+ * is scheduled into the EventList.
+ */
 public class ServicePoint {
-	// Jonorakenne tilauksille
+
+	// queue of orders waiting for service
 	private final LinkedList<Order> queue = new LinkedList<>();
 
-	// Viittaus tapahtumalistaan
+	// reference to the simulation event list
 	private final EventList eventList;
 
-	// Tapahtumatyyppi, joka luodaan palvelun päättyessä
+	// event type generated when service completes
 	private final IEventType completionType;
 
-	// Palveluajan generaattori
+	// default service time generator (exponential distribution)
 	private final Negexp generator;
 
-	// Onko palvelupiste varattu
+	// indicates whether the service point is currently busy
 	private boolean busy = false;
 
-
-	// Tässä kostruktorissa generaattori annetaan valmiina ulkopuolelta jos on tarve
+	/**
+	 * Creates a ServicePoint with an externally provided
+	 * service time generator.
+	 *
+	 * @param generator       service time generator
+	 * @param eventList       reference to the event list
+	 * @param completionType  event type triggered at service completion
+	 */
 	public ServicePoint(Negexp generator, EventList eventList, IEventType completionType) {
 		this.generator = generator;
 		this.eventList = eventList;
 		this.completionType = completionType;
 	}
 
-	// Tämä kostruktori on default versio: luodaan palvelupisteen käyttäen suoraan eksponentiaalijakaumaa, se sopii tilanteseen hyvin
+	/**
+	 * Creates a ServicePoint using an exponential distribution
+	 * with the given mean service time.
+	 *
+	 * @param meanServiceTime mean service time for Negexp distribution
+	 * @param eventList       reference to the event list
+	 * @param completionType  event type triggered at service completion
+	 */
 	public ServicePoint(double meanServiceTime, EventList eventList, IEventType completionType) {
 		this.generator = new Negexp(meanServiceTime);
 		this.eventList = eventList;
 		this.completionType = completionType;
 	}
 
-	// Lisää tilaus jonoon
+	/**
+	 * Adds an order to the service queue.
+	 * If the service point is idle, processing starts immediately.
+	 *
+	 * @param order the order to be added
+	 */
 	public void add(Order order) {
-		// Lisää tilaus palvelupisteen jonoon odottamaan käsittelyä
 		queue.add(order);
-
-		// Jos ei varattu, aloitetaan palvelu
 		if (!isBusy()) {
 			startService();
 		}
 	}
 
-	// Aloittaa palvelun ensimmäiselle jonossa olevalle
-	private void startService() {
-		if (queue.isEmpty()) {
-			return;
-		}
-
-		busy = true;
-
-		double serviceTime = generator.sample();
-		double completionTime = Clock.getInstance().getTime() + serviceTime;
-
-		// Lisätään palvelun päättymistapahtuma
-		Event event = new Event(completionType, completionTime, queue.peek());
-		eventList.add(event);
-	}
-
-	// Poistaa palvellun tilauksen jonosta
+	/**
+	 * Completes service for the current order.
+	 * If there are remaining orders in the queue,
+	 * processing of the next order begins automatically.
+	 *
+	 * @return the order that has finished service,
+	 *         or null if the queue was empty
+	 */
 	public Order finishService() {
 		Order finished = queue.poll();
 		busy = false;
@@ -76,13 +89,40 @@ public class ServicePoint {
 		return finished;
 	}
 
-	// Tarkistaa onko palvelupiste varattu
+	/**
+	 * Returns whether the service point is currently busy.
+	 *
+	 * @return true if processing an order, false otherwise
+	 */
 	public boolean isBusy() {
 		return busy;
 	}
 
-	// Tarkistaa onko jonossa tilauksia
+	/**
+	 * Checks whether there are orders waiting in the queue.
+	 *
+	 * @return true if the queue is not empty
+	 */
 	public boolean hasOrders() {
 		return !queue.isEmpty();
+	}
+
+	/**
+	 * Starts service for the next order in the queue.
+	 * Generates a service completion event and schedules it
+	 * in the EventList.
+	 */
+	private void startService() {
+		if (queue.isEmpty()) {
+			return;
+		}
+
+		busy = true;
+
+		double serviceTime = generator.sample();
+		double completionTime = Clock.getInstance().getTime() + serviceTime;
+
+		Event event = new Event(completionType, completionTime, queue.peek());
+		eventList.add(event);
 	}
 }

--- a/com.mursu/src/main/java/eds/framework/Trace.java
+++ b/com.mursu/src/main/java/eds/framework/Trace.java
@@ -1,21 +1,45 @@
 package eds.framework;
 
-// DONE (by Ks)
-// I don't know yet if we use it
-
+/**
+ * Provides simple logging functionality for the simulation framework.
+ *
+ * Trace allows filtering log output based on severity level.
+ * Only messages with a level greater than or equal to the
+ * currently set trace level are printed to standard output.
+ */
 public class Trace {
-	public enum Level { INFO, WAR, ERR }
 
+	/**
+	 * Logging levels used to control output verbosity.
+	 */
+	public enum Level {
+		INFO, WAR, ERR
+	}
+
+	// current logging threshold
 	private static Level traceLevel = Level.INFO;
 
-	public static void setTraceLevel(Level lvl){
+	/**
+	 * Sets the current trace level.
+	 * Only messages at this level or higher will be printed.
+	 *
+	 * @param lvl the new trace level
+	 */
+	public static void setTraceLevel(Level lvl) {
 		traceLevel = lvl;
 	}
 
-	public static void out(Level lvl, String txt){
+	/**
+	 * Prints a message if its level is greater than or equal
+	 * to the current trace level.
+	 *
+	 * @param lvl the level of the message
+	 * @param txt the message text
+	 */
+	public static void out(Level lvl, String txt) {
 		if (traceLevel == null) return;
 
-		if (lvl.ordinal() >= traceLevel.ordinal()){
+		if (lvl.ordinal() >= traceLevel.ordinal()) {
 			System.out.println(txt);
 		}
 	}


### PR DESCRIPTION
Closes #14 

• Added Javadoc comments to public classes and methods in the eds.framework package for generation of documentation
• Added in pom.xml  maven-javadoc-plugin to generate documentation.
• Currently documentation is generated only for eds.framework. Additional packages can be included later by uncommenting them inside the pom.xml  file, <subpackages> configuration block.

How to generate documentation:

```
cd com.mursu
mvn clean javadoc:javadoc
```

Generated documentation location:

`target/site/apidocs/index.html`

The documentation will include all packages listed inside  <subpackages> in the plugin configuration in pom.xml.

Result: 

<img width="791" height="708" alt="Screenshot 2026-02-26 at 10 50 07" src="https://github.com/user-attachments/assets/f854d4da-0afb-4098-b3a4-2c521d7bf4b3" />

<img width="789" height="707" alt="Screenshot 2026-02-26 at 10 50 39" src="https://github.com/user-attachments/assets/5ce84c2f-4fb7-4153-b946-d41172917f0b" />

